### PR TITLE
Remove Google Test dependency

### DIFF
--- a/include/matcha/matcha.hpp
+++ b/include/matcha/matcha.hpp
@@ -180,16 +180,17 @@ protected:
     }
 };
 
-typedef GTestOutputPolicy DefaultOutputPolicy;
-
-#else
-
-typedef ExceptionOutputPolicy DefaultOutputPolicy;
+#define MATCHA_OUTPUT_POLICY GTestOutputPolicy
 
 #endif
 
+#if !defined(MATCHA_OUTPUT_POLICY)
 
-template<class MatcherPolicy,class ExpectedType = void, class OutputPolicy = DefaultOutputPolicy>
+#define MATCHA_OUTPUT_POLICY StandardOutputPolicy
+
+#endif
+
+template<class MatcherPolicy,class ExpectedType = void, class OutputPolicy = MATCHA_OUTPUT_POLICY>
 class Matcher : private MatcherPolicy, private OutputPolicy {
 public:
     typedef Matcher<MatcherPolicy,ExpectedType> type;

--- a/include/matcha/matcha.hpp
+++ b/include/matcha/matcha.hpp
@@ -33,6 +33,8 @@
 #include <cctype>
 #include <type_traits>
 #include "prettyprint.hpp"
+
+#if defined(MATCHA_GTEST)
 #include "gtest/gtest.h"
 
 /* we need the assertThat logic in a macro, so that
@@ -40,6 +42,13 @@
  */
 #define assertThat(actual,matcher)  \
     ASSERT_PRED_FORMAT2(assertResult, actual, matcher)
+
+#else
+
+#define assertThat(actual, matcher) \
+    assertResult(nullptr, nullptr, actual, matcher)
+
+#endif
 
 namespace matcha {
 
@@ -128,17 +137,33 @@ std::ostream& operator<<(std::ostream& os, const ci_string& str)
     return os.write(str.data(), str.size());
 }
 
-struct DefaultOutputPolicy {
+struct StandardOutputPolicy {
     typedef bool return_type;
 protected:
     bool print(std::string const& expected, std::string const& actual, bool assertion) const {
         if (!assertion) {
             std::cout << "Expected: " << expected << "\n but got: " << actual << std::endl;
-            return false; 
+            return false;
         }
         return true;
     }
 };
+
+struct ExceptionOutputPolicy {
+    typedef void return_type;
+protected:
+    void print(std::string const& expected, std::string const& actual, bool assertion) const {
+        if (!assertion) {
+            std::ostringstream ostream;
+            ostream << "Expected: " << expected << "\n but got: " << actual << std::endl;
+            throw std::logic_error(ostream.str());
+            return;
+        }
+        return;
+    }
+};
+
+#if defined(MATCHA_GTEST)
 
 struct GTestOutputPolicy {
     typedef ::testing::AssertionResult return_type;
@@ -155,7 +180,16 @@ protected:
     }
 };
 
-template<class MatcherPolicy,class ExpectedType = void, class OutputPolicy = GTestOutputPolicy>
+typedef GTestOutputPolicy DefaultOutputPolicy;
+
+#else
+
+typedef ExceptionOutputPolicy DefaultOutputPolicy;
+
+#endif
+
+
+template<class MatcherPolicy,class ExpectedType = void, class OutputPolicy = DefaultOutputPolicy>
 class Matcher : private MatcherPolicy, private OutputPolicy {
 public:
     typedef Matcher<MatcherPolicy,ExpectedType> type;


### PR DESCRIPTION
Matcha should not have Google Test as an explicit dependency.  This pull request makes the GTest code dependent on a MATCHA_GTEST define being present before inclusion of matcha.hpp.

Also, the default output policy can be specified via the macro MATCHA_OUTPUT_POLICY.  If undefined and MATCHA_GTEST is defined, it will be the GTestOutputPolicy, otherwise it will be the StandardOutputPolicy.  It may be:

StandardOutputPolicy - prints to std::cout
ExceptionOutputPolicy - raises a std::logic_error
GTestOutputPolicy - output to Google Test
